### PR TITLE
Run `nw` with `spawn` instead of `exec` to prevent buffer issues.

### DIFF
--- a/lib/commands/nw-test/runner.js
+++ b/lib/commands/nw-test/runner.js
@@ -1,20 +1,18 @@
 'use strict';
 
-var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
 var argv = require('optimist').argv;
 
 runNw(argv['nw-path'], argv['tests-path']);
 
 function runNw(nwPath, testsPath) {
-  var nw = exec(nwPath + ' ' + testsPath);
+  var nw = spawn(nwPath, [testsPath]);
   var hasErrors = false;
-
-  nw.stdout.on('data', function(data) {
-    process.stdout.write(data);
-  });
 
   // Cleanup nw.js output to be TAP (test anything protocol) compliant
   nw.stderr.on('data', function(data) {
+    data = data.toString('utf8');
+
     if (data.indexOf('[qunit-logger]') > -1) {
       data = data.replace(/.*\[qunit-logger] (.*)"", source:.*/g, '$1');
       data = data.replace(/\\"/g, '"');
@@ -30,5 +28,9 @@ function runNw(nwPath, testsPath) {
         process.exit(hasErrors ? 1 : 0);
       }
     }
+  });
+
+  process.on('SIGTERM', function() {
+    nw.kill();
   });
 }

--- a/lib/commands/nw-test/task.js
+++ b/lib/commands/nw-test/task.js
@@ -25,7 +25,7 @@ module.exports = {
           protocol: 'browser'
         },
         'NW.js (CI)': {
-          command: this.nwCommandForCI(options),
+          command: this.nwCommand(options),
           protocol: 'tap'
         }
       }
@@ -34,13 +34,6 @@ module.exports = {
   },
 
   nwCommand: function(options) {
-    var nwPath = safePath(findNW(this.project));
-    var testPath = safePath(path.join(options.outputPath, 'tests'));
-
-    return nwPath + ' ' + testPath;
-  },
-
-  nwCommandForCI: function(options) {
     var command = 'node';
     var commandArgs = safePath(path.join(__dirname, './runner.js'));
     var commandFlags = [

--- a/tests/unit/commands/nw-test/index-test.js
+++ b/tests/unit/commands/nw-test/index-test.js
@@ -106,7 +106,7 @@ describe('ember nw:test command', function() {
 
         var devLauncher = testOptions.launchers[devLauncherName] || {};
         expect(devLauncher.protocol).to.equal('browser');
-        expect(devLauncher.command).to.equal('"nw" "' + path.join(outputPath, 'tests') + '"');
+        expect(devLauncher.command).to.equal('node "' + runnerPath + '" --nw-path="nw" --tests-path="' + path.join(outputPath, 'tests') + '"');
 
         testem.startCI.restore();
       });


### PR DESCRIPTION
Using `require('child_process').exec` to run NW.js can cause the process to crash if the app generates output that exceeds `exec`'s default max buffer size of 200KB. Switching over to `spawn` solves this since there's no buffer involved.

Closes #34.