### PR TITLE
Updated support Ember

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,6 +21,7 @@
   "onevar": false,
   "plusplus": false,
   "regexp": false,
+  "expr": true,
   "undef": true,
   "sub": true,
   "strict": false,

--- a/lib/commands/nw-package.js
+++ b/lib/commands/nw-package.js
@@ -16,6 +16,7 @@ module.exports = {
   ],
 
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
     process.env.EMBER_CLI_NW = true;
   },
 

--- a/lib/commands/nw-test/index.js
+++ b/lib/commands/nw-test/index.js
@@ -18,6 +18,7 @@ module.exports = {
   ],
 
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
     this.assign    = require('lodash/object').assign;
     this.quickTemp = require('quick-temp');
 

--- a/lib/commands/nw.js
+++ b/lib/commands/nw.js
@@ -11,6 +11,7 @@ module.exports = {
   description: 'Builds your app and launches NW.js',
 
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
     process.env.EMBER_CLI_NW = true;
   },
 


### PR DESCRIPTION
## Ember updates
On Ember 2.6 I received deprecation warnings about `init` functions not calling `super`. This resolves those warnings.

```
src$ ember nw
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init
&& this._super.init.apply(this, arguments);` addon: `nw`
    at src/node_modules/ember-cli/lib/models/project.js:404:38
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init
&& this._super.init.apply(this, arguments);` addon: `nw:package`
    at src/node_modules/ember-cli/lib/models/project.js:404:38
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init
&& this._super.init.apply(this, arguments);` addon: `nw:test`
    at src/node_modules/ember-cli/lib/models/project.js:404:38
```

## ~~NWJS Updates~~
~~NWJS 0.13 did not appear to have `window.nwDispatcher` defined which made the shims non-operational. The shims now look for `window.nw`.~~
