### PR TITLE
Add support for NWJS 0.13

### DIFF
--- a/client/nwjs/browser-qunit-adapter.js
+++ b/client/nwjs/browser-qunit-adapter.js
@@ -1,6 +1,6 @@
 (function(window) {
   // Exit immediately if we're not running in NW.js
-  if (typeof window.nwDispatcher === 'undefined') {
+  if (typeof window.nwDispatcher === 'undefined' && typeof window.nw === 'undefined') {
     return;
   }
 

--- a/client/nwjs/reload.js
+++ b/client/nwjs/reload.js
@@ -1,6 +1,6 @@
 /* jshint browser: true */
 (function() {
-  if (!window.nwDispatcher) { return; }
+  if (!window.nwDispatcher && !window.nw) { return; }
 
   // Reload the page when anything in `dist` changes
   var fs = window.requireNode('fs');

--- a/client/nwjs/tap-qunit-adapter.js
+++ b/client/nwjs/tap-qunit-adapter.js
@@ -1,6 +1,6 @@
 (function(window) {
   // Exit immediately if we're not running in NW.js
-  if (typeof window.nwDispatcher === 'undefined') {
+  if (typeof window.nwDispatcher === 'undefined' && typeof window.nw === 'undefined') {
     return;
   }
 

--- a/lib/resources/shim-footer.js
+++ b/lib/resources/shim-footer.js
@@ -1,6 +1,6 @@
 /* jshint browser: true */
 (function(window) {
-  if (!window.nwDispatcher) { return; }
+  if (!window.nwDispatcher && !window.nw) { return; }
 
   // Restore NW.js variables.
   global.window = window;

--- a/lib/resources/shim-head.js
+++ b/lib/resources/shim-head.js
@@ -1,6 +1,6 @@
 /* jshint browser: true */
 (function(window) {
-  if (!window.nwDispatcher) { return; }
+  if (!window.nwDispatcher && !window.nw) { return; }
 
   // Delete some variables that mislead third-party libraries into thinking
   // that the running environment is Node.


### PR DESCRIPTION
Have shims exit only when `window.nwDispatcher` and `window.nw` are undefined. NWJS 0.13 no longer has  `window.nwDispatcher`.